### PR TITLE
chore: add @theschles as TSC member

### DIFF
--- a/TSC_MEMBERS.json
+++ b/TSC_MEMBERS.json
@@ -293,6 +293,16 @@
 		]
 	},
 	{
+		"name": "Philip Schlesinger",
+		"github": "theschles",
+		"slack": "U054UUYBNLF",
+		"twitter": "philschlesinger",
+		"availableForHire": false,
+		"repos": [
+			"jasyncapi"
+		]
+	},
+	{
 		"name": "Pratik Haldankar",
 		"github": "pratik2315",
 		"slack": "U03ADC8FD2S",


### PR DESCRIPTION
Description

- Recently through my work account `@philCryoport` [I began contributing to the jasyncapi codebase](https://github.com/asyncapi/jasyncapi-idea-plugin/pulls?q=is%3Apr+is%3Aclosed+author%3AphilCryoport), hence would like to join TSC.  I'm adding my personal account `@theschles` as...well...you never know if I might leave that company by choice or not...
- Modified TSC_MEMBERS.json to add myself as a member
